### PR TITLE
Use correct filename and path

### DIFF
--- a/qml/pages/Contacts/Contacts.qml
+++ b/qml/pages/Contacts/Contacts.qml
@@ -46,7 +46,7 @@ Rectangle {
         Button {
             id: scanButton
             text: "Scan Badge"
-            onClicked: NavHelper.nav_tray_push("qrc:/PgQrScan.qml")
+            onClicked: NavHelper.nav_tray_push("qrc:/pages/QrScan/QrScan.qml")
             background: Rectangle {
                 color: "lightskyblue"
                 border.color: "black"


### PR DESCRIPTION
In commit ac7543c68ccb1507cf49c1ce6386c63607fe038e the file PgQrScan.qml was renamed to pages/QrScan/QrScan.qml. The Scan Badge button on the Contacts page was still using the old filename.

Closes #54 