### PR TITLE
Reposition Webview when the drawer is opened

### DIFF
--- a/qml/components/navigation/NavMenu.qml
+++ b/qml/components/navigation/NavMenu.qml
@@ -35,10 +35,7 @@ Drawer {
         NavButton{
             id: exhibitors
             buttonText: "Exhibitors"
-            onClicked: {
-                NavHelper.nav_tray_push("qrc:/pages/Exhibitors/Exhibitors.qml");
-                topBar.hideNavBtn = true;
-            }
+            onClicked: NavHelper.nav_tray_push("qrc:/pages/Exhibitors/Exhibitors.qml")
         }
         NavButton{
             id: speakers
@@ -48,10 +45,7 @@ Drawer {
         NavButton{
             id: specialEvents
             buttonText: "Special Events"
-            onClicked: {
-                NavHelper.nav_tray_push("qrc:/pages/SpecialEvents/SpecialEvents.qml");
-                topBar.hideNavBtn = true;
-            }
+            onClicked: NavHelper.nav_tray_push("qrc:/pages/SpecialEvents/SpecialEvents.qml")
         }
         NavButton{
             id: qrScan

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -16,6 +16,8 @@ ApplicationWindow {
     width: 500
     height: 700
 
+    property alias drawerPosition: menu.position
+
     //run app startup code
     Component.onCompleted: Initializer.startup()
 

--- a/qml/pages/CampusMap/CampusMap.qml
+++ b/qml/pages/CampusMap/CampusMap.qml
@@ -8,6 +8,9 @@ WebView {
     height: window.height
     url: "https://www.visitpasadena.com/convention-center/planners/facility-map/"
 
+    // Used to move the WebView when the drawer is opened due to https://doc.qt.io/qt-5/qtwebview-index.html#Limitations
+    x: window.width * window.drawerPosition
+
     onLoadingChanged:{
         runJavaScript("document.querySelector('h1').style.padding='20px 0 0 0'");
         runJavaScript("document.querySelector('header.page-header').remove()");

--- a/qml/pages/Exhibitors/Exhibitors.qml
+++ b/qml/pages/Exhibitors/Exhibitors.qml
@@ -8,6 +8,9 @@ WebView {
     height: window.height
     url: "https://www.socallinuxexpo.org/scale/20x/exhibitors"
 
+    // Used to move the WebView when the drawer is opened due to https://doc.qt.io/qt-5/qtwebview-index.html#Limitations
+    x: window.width * window.drawerPosition
+
     onLoadingChanged:{
         runJavaScript("var nav = document.getElementById('navbar'); nav.parentNode.removeChild(nav)");
         runJavaScript("var lowsec = document.querySelectorAll('div.region-sidebar-first')[1]; lowsec.parentNode.removeChild(lowsec)");

--- a/qml/pages/SpecialEvents/SpecialEvents.qml
+++ b/qml/pages/SpecialEvents/SpecialEvents.qml
@@ -8,6 +8,9 @@ WebView {
     height: window.height
     url: "https://www.socallinuxexpo.org/scale/20x/events"
 
+    // Used to move the WebView when the drawer is opened due to https://doc.qt.io/qt-5/qtwebview-index.html#Limitations
+    x: window.width * window.drawerPosition
+
     onLoadingChanged:{
         runJavaScript("var nav = document.getElementById('navbar'); nav.parentNode.removeChild(nav)");
         runJavaScript("var lowsec = document.querySelectorAll('div.region-sidebar-first')[1]; lowsec.parentNode.removeChild(lowsec)");

--- a/qml/pages/components/PresentationDetail/PresentationDetail.qml
+++ b/qml/pages/components/PresentationDetail/PresentationDetail.qml
@@ -9,6 +9,9 @@ WebView {
     height: window.height
     url: "https://www.socallinuxexpo.org"+page
 
+    // Used to move the WebView when the drawer is opened due to https://doc.qt.io/qt-5/qtwebview-index.html#Limitations
+    x: window.width * window.drawerPosition
+
     onLoadingChanged:{
         runJavaScript("var nav = document.getElementById('navbar'); nav.parentNode.removeChild(nav)");
         runJavaScript("var lowsec = document.querySelectorAll('div.region-sidebar-first')[1]; lowsec.parentNode.removeChild(lowsec)");


### PR DESCRIPTION
Due to a [limitation in Qt](https://doc.qt.io/qt-5/qtwebview-index.html#Limitations), our WebViews cannot be overlapped. Because of this, our drawer menu is hidden when behind the WebView pages when opened.

In this pull request, I came up with the idea of moving the WebView pages to the right when the drawer is opened.

This change has been applied to the following pages

- Campus Map
- Exhibitor Closes #49 
- Special Events Closes #50 
- Presentation details

Also, the NavMenu is no longer hidden on any page.