### PR TITLE
Dynamically load and unload Scanning page

### DIFF
--- a/qml/components/navigation/NavMenu.qml
+++ b/qml/components/navigation/NavMenu.qml
@@ -56,7 +56,7 @@ Drawer {
         NavButton{
             id: qrScan
             buttonText: "Scan Badge QR Code"
-            onClicked: NavHelper.nav_tray_push("qrc:/pages/QrScan/QrScan.qml")
+            onClicked: NavHelper.nav_tray_push("qrc:/pages/QrScan/QrScanLoader.qml")
         }
         NavButton{
             id: campusMap

--- a/qml/pages/Contacts/Contacts.qml
+++ b/qml/pages/Contacts/Contacts.qml
@@ -46,7 +46,7 @@ Rectangle {
         Button {
             id: scanButton
             text: "Scan Badge"
-            onClicked: NavHelper.nav_tray_push("qrc:/pages/QrScan/QrScan.qml")
+            onClicked: NavHelper.nav_tray_push("qrc:/pages/QrScan/QrScanLoader.qml")
             background: Rectangle {
                 color: "lightskyblue"
                 border.color: "black"

--- a/qml/pages/QrScan/QrScanLoader.qml
+++ b/qml/pages/QrScan/QrScanLoader.qml
@@ -1,0 +1,16 @@
+import QtQuick 2.5
+import QtQuick.Controls 2.0
+
+Item {
+    width: 100
+    height: 100
+
+    // load and unload the Scanner page so that the camera is only in use when active
+
+    StackView.onActivated: loader.source = "qrc:/pages/QrScan/QrScan.qml"
+    StackView.onDeactivated: loader.source = ""
+
+    Loader {
+        id: loader
+    }
+}

--- a/qml/qml.qrc
+++ b/qml/qml.qrc
@@ -28,5 +28,6 @@
         <file>pages/Speakers/IndividualSpeaker.qml</file>
         <file>pages/Schedule/SignModel.qml</file>
         <file>pages/CampusMap/CampusMap.qml</file>
+        <file>pages/QrScan/QrScanLoader.qml</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
Closes #60 

By using a loader we can dynamically load and unload the QrScan.qml page. 
The StackView provides signals that lets us see if the page is currently active.

We can put both together and dynamically load and unload the camera when appropriate.