### PR TITLE
Use Labels to avoid binding loops.

### DIFF
--- a/qml/components/modals/CSVcopiedModal.qml
+++ b/qml/components/modals/CSVcopiedModal.qml
@@ -1,27 +1,27 @@
 import QtQuick 2.0
-import QtQuick.Controls 2.2
+import QtQuick.Controls 2.3
 
 Dialog {
     title: "CSV Copied"
     standardButtons: Dialog.Ok
 
-    x: (parent.width / 2) - (implicitWidth / 2)
-    y: (parent.height / 2) - (implicitHeight / 2)
+    parent: Overlay.overlay
+    anchors.centerIn: parent
+
 
     closePolicy: Popup.NoAutoClose
     modal: true
-    onAccepted: this.close()
-    contentItem: Rectangle {
-        color: "lightskyblue"
-        implicitWidth: window.width * 0.75
-        implicitHeight: window.height * 0.10
+    implicitWidth: implicitContentWidth
+    contentItem: Label {
+        id: text
+        text: "CSV Text has been copied to the clipboard and can be pasted into another application."
+        horizontalAlignment: Text.AlignHCenter
+        width: parent.width
+        wrapMode: Text.WordWrap
+        elide: Text.ElideRight
 
-        Text {
-            text: "CSV Text has been copied to the clipboard and can be pasted into another application."
-            horizontalAlignment: Text.AlignCenter
-            wrapMode: Text.WordWrap
-            width: parent.width
-            elide: Text.ElideRight
+        background: Rectangle {
+            color: "lightskyblue"
         }
     }
 }

--- a/qml/components/modals/ErrorModal.qml
+++ b/qml/components/modals/ErrorModal.qml
@@ -1,27 +1,27 @@
 import QtQuick 2.0
-import QtQuick.Controls 2.2
+import QtQuick.Controls 2.3
 
 Dialog {
     title: "Can't Connect to Wi-Fi"
     standardButtons: Dialog.Ok
 
-    x: (parent.width / 2) - (implicitWidth / 2)
-    y: (parent.height / 2) - (implicitHeight / 2)
+    parent: Overlay.overlay
+    anchors.centerIn: parent
+
 
     closePolicy: Popup.NoAutoClose
     modal: true
-    onAccepted: this.close()
-    contentItem: Rectangle {
-        color: "lightskyblue"
-        implicitWidth: parent.contentWidth * 0.75
-        implicitHeight: parent.contentHeight * 0.10
+    implicitWidth: implicitContentWidth
+    contentItem: Label {
+        id: text
+        text: "There was an error downloading the schedule, check your internet connection and try again"
+        horizontalAlignment: Text.AlignHCenter
+        width: parent.width
+        wrapMode: Text.WordWrap
+        elide: Text.ElideRight
 
-        Text {
-            text: "There was an error downloading the schedule, check your internet connection and try again"
-            horizontalAlignment: Text.AlignCenter
-            wrapMode: Text.WordWrap
-            width: parent.width
-            elide: Text.ElideRight
+        background: Rectangle {
+            color: "lightskyblue"
         }
     }
 }

--- a/qml/components/modals/EventAlreadySavedModal.qml
+++ b/qml/components/modals/EventAlreadySavedModal.qml
@@ -1,28 +1,28 @@
 import QtQuick 2.0
-import QtQuick.Controls 2.2
+import QtQuick.Controls 2.3
 
 Dialog {
     id: savedAlreadyModal
     title: "Event exists"
     standardButtons: Dialog.Ok
 
-    x: (parent.width / 2) - (implicitWidth / 2)
-    y: (parent.height / 2) - (implicitHeight / 2)
+    parent: Overlay.overlay
+
+    anchors.centerIn: parent
+
 
     closePolicy: Popup.NoAutoClose
     modal: true
-    onAccepted: this.close()
-    contentItem: Rectangle {
-        color: "lightskyblue"
-        implicitWidth: window.width * 0.75
-        implicitHeight: window.height * 0.10
-
-        Text {
-            text: "Event is already saved in your schedule!"
-            horizontalAlignment: Text.AlignCenter
-            wrapMode: Text.WordWrap
-            width: parent.width
-            elide: Text.ElideRight
+    implicitWidth: implicitContentWidth
+    contentItem: Label {
+        id: text
+        text: "Event is already saved in your schedule!"
+        horizontalAlignment: Text.AlignHCenter
+        width: parent.width
+        wrapMode: Text.WordWrap
+        elide: Text.ElideRight
+        background: Rectangle {
+            color: "lightskyblue"
         }
     }
 }

--- a/qml/components/modals/ScheduleAddedModal.qml
+++ b/qml/components/modals/ScheduleAddedModal.qml
@@ -1,27 +1,27 @@
 import QtQuick 2.0
-import QtQuick.Controls 2.2
+import QtQuick.Controls 2.3
 
 Dialog {
     title: "Success!"
     standardButtons: Dialog.Ok
 
-    x: (parent.width / 2) - (implicitWidth / 2)
-    y: (parent.height / 2) - (implicitHeight / 2)
+    parent: Overlay.overlay
+    anchors.centerIn: parent
+
 
     closePolicy: Popup.NoAutoClose
     modal: true
-    onAccepted: this.close()
-    contentItem: Rectangle {
-        color: "lightskyblue"
-        implicitWidth: window.width * 0.75
-        implicitHeight: window.height * 0.10
+    implicitWidth: implicitContentWidth
+    contentItem: Label {
+        id: text
+        text: "Event was added to your schedule"
+        horizontalAlignment: Text.AlignHCenter
+        width: parent.width
+        wrapMode: Text.WordWrap
+        elide: Text.ElideRight
 
-        Text {
-            text: "Event was added to your schedule"
-            horizontalAlignment: Text.AlignCenter
-            wrapMode: Text.WordWrap
-            width: parent.width
-            elide: Text.ElideRight
+        background: Rectangle {
+            color: "lightskyblue"
         }
     }
 }

--- a/qml/components/modals/ScheduleDeleteModal.qml
+++ b/qml/components/modals/ScheduleDeleteModal.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.0
-import QtQuick.Controls 2.2
+import QtQuick.Controls 2.3
 
 Dialog {
     title: "Delete Entry"
@@ -8,22 +8,23 @@ Dialog {
     property string talkTitle
     property ListModel model
 
-    x: (parent.width / 2) - (implicitWidth / 2)
-    y: (parent.height / 2) - (implicitHeight / 2)
+    parent: Overlay.overlay
+    anchors.centerIn: parent
+
 
     closePolicy: Popup.NoAutoClose
     modal: true
-    contentItem: Rectangle {
-        color: "lightskyblue"
-        implicitWidth: window.width * 0.75
-        implicitHeight: window.height * 0.10
+    implicitWidth: implicitContentWidth
+    contentItem: Label {
+        id: text
+        text: "Press OK to confirm delete"
+        horizontalAlignment: Text.AlignHCenter
+        width: parent.width
+        wrapMode: Text.WordWrap
+        elide: Text.ElideRight
 
-        Text {
-            text: "Press OK to confirm delete"
-            horizontalAlignment: Text.AlignCenter
-            wrapMode: Text.WordWrap
-            width: parent.width
-            elide: Text.ElideRight
+        background: Rectangle {
+            color: "lightskyblue"
         }
     }
 }


### PR DESCRIPTION
This pull request is to address the binding loops printing to the console.

This additionally replaces Text.AlignCenter with [Text.AlignHCenter](https://doc.qt.io/qt-5/qml-qtquick-text.html#horizontalAlignment-prop) as the former was not a valid enum in QML for Text.


This does have some cosmetic differences, but does not change what the popups say or how they function.