### PR TITLE
Bind currendDay to TabBar's currentItem.item

### DIFF
--- a/qml/pages/components/ScheduleFilter/ScheduleFilter.qml
+++ b/qml/pages/components/ScheduleFilter/ScheduleFilter.qml
@@ -7,78 +7,37 @@ ColumnLayout {
     FontLoader { id: sourceCodeProBlack; source: "qrc:/fonts/SourceCodePro-Black.ttf" }
     z: 5
 
-    property string currentDay: ""
+    property string currentDay: bar.currentItem.text
     property var listRef: null
 
     TabBar {
         id: bar
         spacing: 0
 
-        TabButton {
-            id: thursdayButton
-            text: "<font color=\"#1D3261\">THURSDAY</font>"
-            font.family: sourceCodeProBlack.name
-            font.pointSize: 12
-            font.weight: Font.Bold
-            width: window.width/4
-            background: Rectangle {
-                color: (bar.currentIndex == 0 ? "#eb6c4b" : "#e9f2f9")
-            }
-            onClicked: {
-                layout.currentDay = "thursday";
-                if(layout.listRef){
-                    layout.listRef.positionViewAtBeginning();
+        Repeater {
+            model: ["thursday", "friday", "saturday", "sunday"]
+            delegate: TabButton {
+                id: tabButton
+                text: modelData
+
+                contentItem: Text {
+                    text: tabButton.text.toUpperCase()
+                    color: "#1D3261"
+                    font.family: sourceCodeProBlack.name
+                    font.pointSize: 12
+                    font.weight: Font.Bold
+                    horizontalAlignment: Text.AlignHCenter
+                    elide: Text.ElideRight
+
                 }
-            }
-        }
-        TabButton {
-            id: fridayButton
-            text: "<font color=\"#1D3261\">FRIDAY</font>"
-            font.family: sourceCodeProBlack.name
-            font.pointSize: 12
-            font.weight: Font.Bold
-            width: window.width/4
-            background: Rectangle {
-                color: (bar.currentIndex == 1 ? "#eb6c4b" : "#e9f2f9")
-            }
-            onClicked: {
-                layout.currentDay = "friday";
-                if(layout.listRef){
-                    layout.listRef.positionViewAtBeginning();
+                width: window.width/4
+                background: Rectangle {
+                    color: tabButton.checked ? "#eb6c4b" : "#e9f2f9"
                 }
-            }
-        }
-        TabButton {
-            id: saturdayButton
-            text: "<font color=\"#1D3261\">SATURDAY</font>"
-            font.family: sourceCodeProBlack.name
-            font.pointSize: 12
-            font.weight: Font.Bold
-            width: window.width/4
-            background: Rectangle {
-                color: (bar.currentIndex == 2 ? "#eb6c4b" : "#e9f2f9")
-            }
-            onClicked: {
-                layout.currentDay = "saturday";
-                if(layout.listRef){
-                    layout.listRef.positionViewAtBeginning();
-                }
-            }
-        }
-        TabButton {
-            id: sundayButton
-            text: "<font color=\"#1D3261\">SUNDAY</font>"
-            font.family: sourceCodeProBlack.name
-            font.pointSize: 12
-            font.weight: Font.Bold
-            width: window.width/4
-            background: Rectangle {
-                color: (bar.currentIndex == 3 ? "#eb6c4b" : "#e9f2f9")
-            }
-            onClicked: {
-                layout.currentDay = "sunday";
-                if(layout.listRef){
-                    layout.listRef.positionViewAtBeginning();
+                onClicked: {
+                    if(layout.listRef){
+                        layout.listRef.positionViewAtBeginning();
+                    }
                 }
             }
         }


### PR DESCRIPTION
The initial value of currentDay was empty string. This caused events of all days to be shown on initial page view. We can avoid this by binding the current item to the day.

closes #78 