### PR TITLE
Restore Android OpenSSL and bump submodule to latest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,8 @@ qt6_add_resources(scale-conf "fonts"
 if(ANDROID)
     set_property(TARGET scale-conf APPEND PROPERTY QT_ANDROID_PACKAGE_SOURCE_DIR
     ${CMAKE_CURRENT_SOURCE_DIR}/android)
+    include(android_openssl/android_openssl.cmake)
+    add_android_openssl_libraries(scale-conf)
 
 endif()
 


### PR DESCRIPTION
This adds Android openssl back to the CMAKE project as well as updates it to the latest commit.

We will likely need to do another update before the event.