### PR TITLE
Explicitly tell the Background Rectangle to fill the area

### DIFF
--- a/qml/components/navigation/NavButton.qml
+++ b/qml/components/navigation/NavButton.qml
@@ -42,6 +42,7 @@ Button {
 
     background: Rectangle {
         color: "#e9f2f9"
+        anchors.fill: parent
         //border.color: "black"
     }
     //padding: 12


### PR DESCRIPTION
I explicitly told the rectangle that supplied the background colour to fill the space of the NavButton. This should prevent gaps from appearing between the button elements.

closes #114 